### PR TITLE
Implement unit tests for Python API - Issue #1

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,9 +7,9 @@ It has OpenTelemetry auto-instrumentation enabled.
 Install dependencies:
 
 ```bash
-python3.11 -m venv venv
+python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 ```
 
 Run PostgreSQL via Docker:

--- a/api/main_test.py
+++ b/api/main_test.py
@@ -1,0 +1,111 @@
+import pytest
+from typing import Any, AsyncGenerator
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from httpx import AsyncClient, ASGITransport
+from .main import app, get_db
+
+# Use SQLite in-memory for tests
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+# Create a new engine using SQLite for testing purposes
+test_engine = create_async_engine(DATABASE_URL, echo=True, future=True)
+
+# Create a sessionmaker that binds to the test engine
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine, class_=AsyncSession)
+
+# Override the get_db dependency to use the SQLite in-memory session
+async def override_get_db() -> AsyncGenerator[AsyncSession, Any]:
+    async with TestSessionLocal() as session:
+        yield session
+
+app.dependency_overrides[get_db] = override_get_db
+
+@pytest.fixture
+async def setup_db():
+    # Create the tables in the test database
+    async with test_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield
+    # Cleanup tables after tests
+    async with test_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+
+@pytest.mark.asyncio
+async def test_health_check():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "OK"}
+
+@pytest.mark.asyncio
+async def test_create_todo(setup_db):
+    todo_data = {
+        "title": "Test Todo",
+        "description": "A test todo description",
+        "priority": 3
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/todos/", json=todo_data)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == todo_data["title"]
+    assert data["description"] == todo_data["description"]
+    assert data["priority"] == todo_data["priority"]
+    assert data["completed"] is False
+
+@pytest.mark.asyncio
+async def test_read_todos(setup_db):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/todos/")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+@pytest.mark.asyncio
+async def test_read_todo_not_found(setup_db):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/todos/999")  # Non-existent ID
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Todo not found"}
+
+@pytest.mark.asyncio
+async def test_update_todo(setup_db):
+    todo_data = {
+        "title": "Test Todo Update",
+        "description": "A test todo update",
+        "priority": 2
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        # First create a todo
+        create_response = await ac.post("/todos/", json=todo_data)
+        todo_id = create_response.json()["id"]
+
+        # Now update the todo
+        update_data = {"completed": True}
+        update_response = await ac.put(f"/todos/{todo_id}", json=update_data)
+        assert update_response.status_code == 200
+        updated_todo = update_response.json()
+        assert updated_todo["completed"] is True
+
+@pytest.mark.asyncio
+async def test_delete_todo(setup_db):
+    todo_data = {
+        "title": "Test Todo Delete",
+        "description": "A test todo to be deleted",
+        "priority": 1
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        # First create a todo
+        create_response = await ac.post("/todos/", json=todo_data)
+        todo_id = create_response.json()["id"]
+
+        # Delete the todo
+        delete_response = await ac.delete(f"/todos/{todo_id}")
+        assert delete_response.status_code == 200
+        deleted_todo = delete_response.json()
+        assert deleted_todo["id"] == todo_id
+
+        # Verify deletion
+        get_response = await ac.get(f"/todos/{todo_id}")
+        assert get_response.status_code == 404

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,3 +9,8 @@ opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-sqlalchemy
 opentelemetry-instrumentation-logging
 opentelemetry-exporter-otlp
+pytest
+pytest-asyncio
+pytest-anyio
+httpx
+aiosqlite

--- a/e2e/config/mimir-config.yaml
+++ b/e2e/config/mimir-config.yaml
@@ -23,16 +23,19 @@ compactor:
 
 distributor:
   ring:
-    instance_addr: 127.0.0.1
     kvstore:
       store: memberlist
+  pool:
+    health_check_ingesters: true
 
 ingester:
   ring:
-    instance_addr: 127.0.0.1
     kvstore:
       store: memberlist
     replication_factor: 1
+    min_ready_duration: 0s
+    final_sleep: 0s
+    num_tokens: 512
 
 ruler_storage:
   backend: filesystem

--- a/e2e/config/otelcol-config.yaml
+++ b/e2e/config/otelcol-config.yaml
@@ -23,8 +23,6 @@ exporters:
 
 processors:
   batch:
-  spanmetrics:
-    metrics_exporter: prometheusremotewrite
 
 connectors:
   spanmetrics:

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -13,11 +13,6 @@ services:
     - ./config/mimir-config.yaml:/etc/mimir-config.yaml
     environment:
       TZ: America/New_York
-    healthcheck:
-      test: wget --quiet --tries=1 --spider http://localhost:9009/ready || exit 1
-      interval: 10s
-      timeout: 1s
-      retries: 10
 
   loki:
     image: grafana/loki:latest
@@ -84,7 +79,7 @@ services:
     - 4318:4318 # otlp http
     depends_on:
       mimir:
-        condition: service_healthy
+        condition: service_started
       loki:
         condition: service_healthy
       tempo:
@@ -102,7 +97,7 @@ services:
     container_name: grafana
     depends_on:
       mimir:
-        condition: service_healthy
+        condition: service_started
       loki:
         condition: service_healthy
       tempo:


### PR DESCRIPTION
This PR implements async pytest tests for the API.

Additionally, a few changes were added to the end-to-end configuration to ensure everything works with all the applications' latest versions.

Please note that even if the `execute` method is deprecated in favor of `exec` for SQLModel/AsyncSession, I switched to `execute` to ensure the test works, as `exec` is not fully supported for testing purposes.